### PR TITLE
Update IndexHTML.php

### DIFF
--- a/src/NorbertTech/StaticContentGeneratorBundle/Content/OutputPathResolver/IndexHTML.php
+++ b/src/NorbertTech/StaticContentGeneratorBundle/Content/OutputPathResolver/IndexHTML.php
@@ -110,6 +110,6 @@ final class IndexHTML implements OutputPathResolver
             }
         }
 
-        return \rtrim($this->outputDirectory . '/') . DIRECTORY_SEPARATOR . \ltrim($content->path(), '/') . DIRECTORY_SEPARATOR . 'index.html';
+        return \rtrim($this->outputDirectory , '/') . DIRECTORY_SEPARATOR . \ltrim($content->path(), '/') . DIRECTORY_SEPARATOR . 'index.html';
     }
 }


### PR DESCRIPTION
rtrim typo fix, instead of fixing slash path it adds double slash